### PR TITLE
Add default fetchInit options method POST

### DIFF
--- a/rpcClient.ts
+++ b/rpcClient.ts
@@ -126,6 +126,7 @@ class Client {
     this.handleUnsuccessfulResponse = handleUnsuccessfulResponse
     this.fetchInit = {
       ...options,
+      method: "POST",
       headers: { ...options.headers, "Content-Type": "application/json" },
     }
   }


### PR DESCRIPTION
Hi there, 
I tried to use gentleRpc with bitcoin-core RPC and it was not working. 
After some debugging time to understand why, i found this default option missing in the request.