### PR TITLE
Allow listening for websocket notifications

### DIFF
--- a/client/proxy.ts
+++ b/client/proxy.ts
@@ -62,6 +62,7 @@ type WsProxyFunction = {
     params?: RpcRequest["params"],
   ) => ReturnType<WsRemote["call"]>;
   subscribe: () => ReturnType<WsRemote["subscribe"]>;
+  listen: () => ReturnType<WsRemote["listen"]>;
 };
 export type WsProxy =
   & {
@@ -79,6 +80,7 @@ export const wsProxyHandler = {
       const proxyFunction: WsProxyFunction = (args?) => client.call(name, args);
       proxyFunction.notify = (args?) => client.call(name, args, true);
       proxyFunction.subscribe = () => client.subscribe(name);
+      proxyFunction.listen = () => client.listen(name);
       return proxyFunction;
     }
   },

--- a/client/validation.ts
+++ b/client/validation.ts
@@ -3,9 +3,18 @@ import { BadServerDataError } from "./error.ts";
 import type {
   JsonValue,
   RpcFailure,
+  RpcNotification,
   RpcResponseBasis,
   RpcSuccess,
 } from "../json_rpc_types.ts";
+
+export function validateRpcNotification(data: any): data is RpcNotification {
+  return (
+    data?.jsonrpc === "2.0" &&
+    typeof data.method === "string" &&
+    typeof data.id === "undefined"
+  );
+}
 
 function validateRpcBasis(data: any): data is RpcResponseBasis {
   return (

--- a/client/ws.ts
+++ b/client/ws.ts
@@ -1,5 +1,5 @@
 import { createRequest } from "./creation.ts";
-import { validateResponse } from "./validation.ts";
+import { validateResponse, validateRpcNotification } from "./validation.ts";
 import { BadServerDataError } from "./error.ts";
 
 import type { JsonValue, RpcRequest } from "../json_rpc_types.ts";
@@ -108,6 +108,25 @@ export class Remote {
     }
   }
 
+  private async *iterateNotifications(
+    eventName: RpcRequest["method"],
+  ): AsyncGenerator<JsonValue> {
+    while (this.socket.readyState < 2) {
+      const payloadData = await this.payloadData;
+      if (payloadData === null) {
+        break;
+      }
+      const parsedData = JSON.parse(payloadData);
+
+      if (validateRpcNotification(parsedData)) {
+        const rpcNotification = parsedData;
+        if (rpcNotification.method === eventName) {
+          yield rpcNotification.params || null;
+        }
+      }
+    }
+  }
+
   call(
     method: RpcRequest["method"],
     params: RpcRequest["params"],
@@ -171,6 +190,14 @@ export class Remote {
           }
         ))));
       },
+    };
+  }
+
+  listen(
+    eventName: RpcRequest["method"],
+  ) {
+    return {
+      generator: this.iterateNotifications(eventName),
     };
   }
 }

--- a/client/ws.ts
+++ b/client/ws.ts
@@ -2,7 +2,7 @@ import { createRequest } from "./creation.ts";
 import { validateResponse, validateRpcNotification } from "./validation.ts";
 import { BadServerDataError } from "./error.ts";
 
-import type { JsonValue, RpcRequest } from "../json_rpc_types.ts";
+import type { JsonObject, JsonValue, RpcRequest } from "../json_rpc_types.ts";
 
 function isObject(obj: unknown): obj is Record<string, unknown> {
   return (
@@ -47,9 +47,29 @@ export class Remote {
     return this.textDecoder || (this.textDecoder = new TextDecoder());
   }
 
-  private async *iterateOverPayloadData(
+  private async *iterateRequests(
     rpcRequest: RpcRequest,
-    { isOnetime }: { isOnetime: boolean },
+  ): AsyncGenerator<JsonValue> {
+    while (this.socket.readyState < 2) {
+      const payloadData = await this.payloadData;
+      if (payloadData === null) {
+        break;
+      }
+      const parsedData = JSON.parse(payloadData);
+
+      // Batch emits are handled by the subscription iterator
+      if (Array.isArray(parsedData)) continue;
+
+      const rpcResponse = validateResponse(parsedData);
+      if (rpcResponse.id === rpcRequest.id) {
+        yield rpcResponse.result;
+        break;
+      }
+    }
+  }
+
+  private async *iterateSubscriptions(
+    rpcRequest: RpcRequest,
   ): AsyncGenerator<JsonValue> {
     while (this.socket.readyState < 2) {
       try {
@@ -59,50 +79,51 @@ export class Remote {
         }
         const parsedData = JSON.parse(payloadData);
 
-        //Processes for the method 'emitBatch':
-        if (Array.isArray(parsedData) && !isOnetime && parsedData.length > 0) {
-          const invalid = parsedData.map(validateResponse).find((res) =>
+        // Process for the method 'emitBatch':
+        if (Array.isArray(parsedData) && parsedData.length > 0) {
+          const rpcResponses = parsedData.map(validateResponse);
+          const invalid = rpcResponses.find((res) =>
             !isObject(res.result) || res.result.event !== "emitted"
           );
           if (invalid) {
             throw new BadServerDataError(
-              invalid.id ? invalid.id : null,
+              invalid.id || null,
               "The server returned an invalid batch response.",
               -32004,
             );
           } else {
-            continue;
+            for (const res of rpcResponses) {
+              if ((res.result as JsonObject).id === rpcRequest.id) {
+                yield res.result;
+              }
+            }
           }
         } else {
           const rpcResponse = validateResponse(parsedData);
           if (
-            !isOnetime &&
             isObject(rpcResponse.result) &&
             rpcResponse.result.id === rpcRequest.id
           ) {
-            if (
-              rpcResponse.result.event === "subscribed" ||
-              rpcResponse.result.event === "emitted"
-            ) {
-              continue;
-            }
-            if (rpcResponse.result.event === "unsubscribed") {
-              break;
-            }
-          }
-          if (rpcResponse.id === rpcRequest.id) {
-            yield rpcResponse.result;
-            if (isOnetime) {
-              break;
+            switch (rpcResponse.result.event) {
+              case "subscribed":
+                continue;
+              case "unsubscribed":
+                break;
+              case "emitted":
+                yield rpcResponse.result;
+                break;
+              default:
+                throw new BadServerDataError(
+                  rpcResponse.id ? rpcResponse.id : null,
+                  "The server returned an invalid response.",
+                  -32004,
+                );
             }
           }
         }
       } catch (err) {
         if (err.id === rpcRequest.id) {
           yield Promise.reject(err);
-          if (isOnetime) {
-            break;
-          }
         }
       }
     }
@@ -141,9 +162,7 @@ export class Remote {
       rpcRequest,
     ));
     if (isNotification) return Promise.resolve(undefined);
-    const generator = this.iterateOverPayloadData(rpcRequest, {
-      isOnetime: true,
-    });
+    const generator = this.iterateRequests(rpcRequest);
     return generator.next().then((p) => p.value);
   }
 
@@ -160,9 +179,7 @@ export class Remote {
       },
     ));
     return {
-      generator: this.iterateOverPayloadData(rpcRequest, {
-        isOnetime: false,
-      }),
+      generator: this.iterateSubscriptions(rpcRequest),
       unsubscribe: (params?: RpcRequest["params"]): void => {
         const rpcRequestUnsubscription = createRequest({
           method: "unsubscribe",

--- a/json_rpc_types.ts
+++ b/json_rpc_types.ts
@@ -6,11 +6,14 @@ export type RpcId = number | string | null;
 export type RpcParams = JsonArray | JsonObject;
 export type RpcMethod = string;
 
-export interface RpcRequest {
+export interface RpcNotification {
   jsonrpc: RpcVersion;
   method: RpcMethod;
-  id?: RpcId;
   params?: RpcParams;
+}
+
+export interface RpcRequest extends RpcNotification {
+  id?: RpcId;
 }
 
 export type RpcResponse = RpcSuccess | RpcFailure;

--- a/server/ws_internal_methods.ts
+++ b/server/ws_internal_methods.ts
@@ -47,7 +47,12 @@ function emit(
     dispatchEvent(
       new CustomEvent("emit", { detail: { method, params } }),
     );
-    return { event: "emitted", id, method };
+    return {
+      event: "emitted",
+      id,
+      method,
+      ...(typeof params !== "undefined" ? { params } : {}),
+    };
   } else {
     throw new Error("Wrong arguments.");
   }


### PR DESCRIPTION
Websocket notifications are "requests" without an ID. Implementations differ, but some servers use this format to send out events to clients (as opposed to the [also nonstandard] `subscription` method).

Since WebSocket notifications don't require acknowledgment or error handling, this implementation does not handle errors, it simply does not handle anything that is not a notification.

I tried to wrangle the notification condition into the existing `iterateOverPayloadData` generator, but it didn't want to work. So I had to add a smaller, second generator.

This works in my setup, but I marked this PR as a draft to get your input if the way I did this is in the spirit of this library, or if you have a better idea.

Thanks! =)